### PR TITLE
Fix BCM bug in hms_shared.C and rootlogon.C path

### DIFF
--- a/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
+++ b/SCRIPTS/HMS/PRODUCTION/replay_production_hms.C
@@ -31,8 +31,6 @@ void replay_production_hms(Int_t RunNumber=0, Int_t MaxEvent=0) {
   //Initialize HMS single-arm DAQ with detectors
   //Shared HMS apparatus setup located in ../hms_shared.h
   setupApparatus();
-  THcBCMCurrent* bcm = new THcBCMCurrent("H.bcm", "BCM Module");
-  gHaPhysics->Add(bcm);
 
   // Set up the analyzer - we use the standard one,
   THcAnalyzer* analyzer = new THcAnalyzer;

--- a/SCRIPTS/HMS/hms_shared.h
+++ b/SCRIPTS/HMS/hms_shared.h
@@ -42,7 +42,6 @@ void setupParms(Int_t RunNumber) {
   gHcParms->Load("PARAM/HMS/GEN/h_fadc_debug_sp18.param");
   
   // Load BCM values
-  ifstream bcmFile;
   TString bcmParamFile = Form("PARAM/HMS/BCM/bcmcurrent_%d.param", RunNumber);
   bcmFile.open(bcmParamFile);
   if (bcmFile.is_open()) gHcParms->Load(bcmParamFile);

--- a/rootlogon.C
+++ b/rootlogon.C
@@ -1,3 +1,3 @@
 {
-   gInterpreter->AddIncludePath("/group/c-xem2/cmorean/FullExperiment/hallc_replay_XEM/");
+  gInterpreter->AddIncludePath(gSystem->pwd());
 }


### PR DESCRIPTION
There was a bug in hms_shared.C that caused the BCMs to not be added to the tree properly. This bug was fixed.

In addition, the rootlogon.C path was originally hardcoded to a specific hallc_replay directory, rather than to the current directory. This caused replay scripts to load files from that other directory instead of the current one. This was fixed, so now it points to the current directory.