### PR TITLE
Update report file templates and zero offsets for HMS and SHMS theta and p_cen

### DIFF
--- a/PARAM/HMS/GEN/hmsflags_fa22.param
+++ b/PARAM/HMS/GEN/hmsflags_fa22.param
@@ -31,9 +31,9 @@ hphi_offset = 0.
                           ; Data taken with fields set by field00.f or later should set to 2000.
 ; These offsets are determined from elastic ep data.
 ; central field  correction
-  hpcentral_offset = -0.00188     
-  hthetacentral_offset = 0.0 ; (rad) 
-  h_oopcentral_offset = 0.0  ; (rad)
+  hpcentral_offset = -0.00 ; (%)     
+  hthetacentral_offset = 0.00 ; (rad) 
+  h_oopcentral_offset = 0.00  ; (rad)
 ; sets hpcentral = hpcentral * ( 1. + hpcentral_offset / 100. )
 ;      htheta_lab=htheta_lab + hthetacentral_offset/degree 
 

--- a/SCRIPTS/HMS/hms_shared.h
+++ b/SCRIPTS/HMS/hms_shared.h
@@ -37,9 +37,8 @@ void setupParms(Int_t RunNumber) {
   // Load parameters for SHMS trigger configuration
   gHcParms->Load(gHcParms->GetString("g_ctp_trig_config_filename"));
   // Load hpcentral momentum offset 
-  gHcParms->Load("PARAM/HMS/GEN/hpcentral_function_sp18.param");
   // Load fadc debug parameters
-  gHcParms->Load("PARAM/HMS/GEN/h_fadc_debug_sp18.param");
+  gHcParms->Load("PARAM/HMS/GEN/h_fadc_debug_fa22.param");
   
   // Load BCM values
   TString bcmParamFile = Form("PARAM/HMS/BCM/bcmcurrent_%d.param", RunNumber);

--- a/TEMPLATES/HMS/PRODUCTION/hstackana_production_fa22.template
+++ b/TEMPLATES/HMS/PRODUCTION/hstackana_production_fa22.template
@@ -2,11 +2,15 @@
 * General Run Information
 **************************
 
-Run Num     : {gen_run_number}
-Momentum    : {hpcentral:%.3f}
-Target AMU  : {gtargmass_amu:%.2f}
-Spec Theta  : {htheta_lab:%.4f}
-Beam Energy : {gpbeam:%.3f}
+Run Num           : {gen_run_number}
+Raw Momentum      : {hpcentral:%.3f}
+Momentum Offset   : {hpcentral_offset:%.3f}
+True Momentum     : {hpcentral*(1+hpcentral_offset*0.01):%.3f}
+Target AMU        : {gtargmass_amu:%.2f}
+Raw Spec Theta    : {htheta_lab:%.4f}
+Spec Theta Offset : {hthetacentral_offset:%.4f}
+True Spec Theta   : {htheta_lab+hthetacentral_offset*180/pi:%.4f}
+Beam Energy       : {gpbeam:%.3f}
 
 1 MHz Pulses : {H.1MHz.scaler}
 Run Length   : {H.1MHz.scalerTime:%.3f} sec

--- a/TEMPLATES/SHMS/PRODUCTION/pstackana_production_fa22.template
+++ b/TEMPLATES/SHMS/PRODUCTION/pstackana_production_fa22.template
@@ -3,11 +3,15 @@
 * General Run Information
 **************************
 
-Run Num     : {gen_run_number}
-Momentum    : {ppcentral:%.3f}
-Target AMU  : {gtargmass_amu:%.2f}
-Spec Theta  : {ptheta_lab:%.4f}
-Beam Energy : {gpbeam:%.3f}
+Run Num           : {gen_run_number}
+Raw Momentum      : {ppcentral:%.3f}
+Momentum Offset   : {ppcentral_offset:%.3f}
+True Momentum     : {ppcentral*(1+ppcentral_offset*0.01):%.3f}
+Target AMU        : {gtargmass_amu:%.2f}
+Raw Spec Theta    : {ptheta_lab:%.4f}
+Spec Theta Offset : {pthetacentral_offset:%.4f}
+True Spec Theta   : {ptheta_lab+pthetacentral_offset*180/pi:%.4f}
+Beam Energy       : {gpbeam:%.3f}
 
 1 MHz Pulses : {P.1MHz.scaler}
 Run Length   : {P.1MHz.scalerTime:%.3f} sec


### PR DESCRIPTION
The report file templates for the HMS and SHMS have been updated to include the raw values, offsets, and "true" (offset applied) values for central angle and momentum. All offsets have been set to 0 in (s)hmsflags_fa22.param files.

Also, hms_shared.h was loading a file that overwrote the offset set in hmsflags_fa22.param, and was also using the h_fadc_debug_sp18.param file. The offending overwriting file was removed and h_fadc_debug_fa22.param is now being used in place of the sp18 version. 