### PR TITLE
Add spectrometer offsets to SHMS HMS and COIN REPORT_OUTPUT (template file).

### DIFF
--- a/DBASE/COIN/standard.database
+++ b/DBASE/COIN/standard.database
@@ -7,7 +7,7 @@ g_ctp_bcm_calib_filename   = "PARAM/GEN/gscalers_fa22.param"
 g_ctp_optics_filename      = "PARAM/COIN/GEN/coin_optics_fa22.param"
 g_ctp_trig_config_filename = "PARAM/TRIG/tcoin_fa22.param"
 g_ctp_map_filename        = "MAPS/COIN/DETEC/coin_fa22.map"
-g_ctp_template_filename    = "TEMPLATES/SHMS/PRODUCTION/pstackana_production_sp18.template"
+g_ctp_template_filename    = "TEMPLATES/COIN/PRODUCTION/coin_production.template"
 
 0-6008
 g_ctp_parm_filename       = "DBASE/COIN/general_pt.param"

--- a/DBASE/SHMS/standard.database
+++ b/DBASE/SHMS/standard.database
@@ -33,7 +33,7 @@ g_ctp_bcm_calib_filename   = "PARAM/GEN/BCM/gbcm_period2_fa22.param"
 g_ctp_optics_filename      = "PARAM/SHMS/GEN/pcana_fa22.param"
 g_ctp_map_filename         = "MAPS/SHMS/DETEC/STACK/shms_stack_fa22.map"
 g_ctp_trig_config_filename = "PARAM/TRIG/tshms_fa22.param"
-g_ctp_template_filename    = "TEMPLATES/SHMS/PRODUCTION/pstackana_production_sp18.template"
+g_ctp_template_filename    = "TEMPLATES/SHMS/PRODUCTION/pstackana_production_fa22.template"
 
 
 ; Specialized detector calibrations w.r.t. kinematic settings

--- a/SCRIPTS/COIN/PRODUCTION/replay_coincidence_elastic.C
+++ b/SCRIPTS/COIN/PRODUCTION/replay_coincidence_elastic.C
@@ -262,7 +262,7 @@ void replay_coincidence_elastic (Int_t RunNumber = 0, Int_t MaxEvent = 0) {
   // Start the actual analysis.
   analyzer->Process(run);
   // Create report file from template
-  //analyzer->PrintReport("TEMPLATES/COIN/PRODUCTION/coin_production.template",
-  //			Form("REPORT_OUTPUT/COIN/HeeP/replay_coin_production_%d_%d.report", RunNumber, MaxEvent));  // optional
+  analyzer->PrintReport(gHcParms->GetString("g_ctp_template_filename"),
+  			Form("REPORT_OUTPUT/COIN/HeeP/replay_coin_production_%d_%d.report", RunNumber, MaxEvent));  // optional
 
 }

--- a/SCRIPTS/COIN/PRODUCTION/replay_production_coin_hElec_pProt.C
+++ b/SCRIPTS/COIN/PRODUCTION/replay_production_coin_hElec_pProt.C
@@ -23,6 +23,7 @@ void replay_production_coin_hElec_pProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   pathList.push_back("./raw/../raw.copiedtotape");
   pathList.push_back("./CACHE_LINKS/cache_pionlt");
   pathList.push_back("./CACHE_LINKS/cache_cafe"); 
+  pathList.push_back("./CACHE_LINKS/cache_xem2"); 
 
   //const char* RunFileNamePattern = "raw/coin_all_%05d.dat";
   const char* ROOTFileNamePattern = "ROOTfiles/COIN/HeeP/coin_replay_production_%d_%d.root";
@@ -277,7 +278,7 @@ void replay_production_coin_hElec_pProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   // Start the actual analysis.
   analyzer->Process(run);
   // Create report file from template
-  analyzer->PrintReport("TEMPLATES/COIN/PRODUCTION/coin_production.template",
+  analyzer->PrintReport(gHcParms->GetString("g_ctp_template_filename"),
   			Form("REPORT_OUTPUT/COIN/PRODUCTION/replay_coin_production_%d_%d.report", RunNumber, MaxEvent));  // optional
 
 }

--- a/SCRIPTS/COIN/PRODUCTION/replay_production_coin_pElec_hProt.C
+++ b/SCRIPTS/COIN/PRODUCTION/replay_production_coin_pElec_hProt.C
@@ -276,7 +276,7 @@ void replay_production_coin_pElec_hProt (Int_t RunNumber = 0, Int_t MaxEvent = 0
   // Start the actual analysis.
   analyzer->Process(run);
   // Create report file from template
-  analyzer->PrintReport("TEMPLATES/COIN/PRODUCTION/coin_production.template",
+  analyzer->PrintReport(gHcParms->GetString("g_ctp_template_filename"),
   			Form("REPORT_OUTPUT/COIN/HeeP/replay_coin_production_%d_%d.report", RunNumber, MaxEvent));  // optional
 
 }

--- a/TEMPLATES/COIN/PRODUCTION/coin_production.template
+++ b/TEMPLATES/COIN/PRODUCTION/coin_production.template
@@ -82,6 +82,14 @@ SHMS BCM4B Beam Cut Charge: {P.BCM4B.scalerChargeCut/1000.:%.3f} mC
 SHMS BCM4C Beam Cut Charge: {P.BCM4C.scalerChargeCut/1000.:%.3f} mC		 
 SHMS Unser Beam Cut Charge: {P.Unser.scalerChargeCut/1000.:%.3f} mC
  
+**************************
+* Spectrometer Mispointing
+**************************
+SHMS X Mispointing:	{pmispointing_x:%.3f}
+SHMS Y Mispointing:	{pmispointing_y:%.3f}
+
+HMS X Mispointing:		{hmispointing_x:%.3f}
+HMS Y Mispointing:		{hmispointing_y:%.3f}
 
 ********************
 * DAQ Configuration

--- a/TEMPLATES/COIN/PRODUCTION/coin_production_fa22.template
+++ b/TEMPLATES/COIN/PRODUCTION/coin_production_fa22.template
@@ -61,8 +61,11 @@ Unser Beam Cut Charge: {P.Unser.scalerChargeCut:%.3f} uC
 **************************
 * Spectrometer Mispointing
 **************************
-X Mispointing:	{pmispointing_x:%.3f}
-Y Mispointing:	{pmispointing_y:%.3f}
+SHMS X Mispointing:	{pmispointing_x:%.3f}
+SHMS Y Mispointing:	{pmispointing_y:%.3f}
+
+HMS X Mispointing:		{hmispointing_x:%.3f}
+HMS Y Mispointing:		{hmispointing_y:%.3f}
 
 ********************
 * DAQ Configuration

--- a/TEMPLATES/HMS/PRODUCTION/hstackana_production_fa22.template
+++ b/TEMPLATES/HMS/PRODUCTION/hstackana_production_fa22.template
@@ -49,6 +49,12 @@ BCM4B Beam Cut Charge: {H.BCM4B.scalerChargeCut:%.3f} uC
 BCM4C Beam Cut Charge: {H.BCM4C.scalerChargeCut:%.3f} uC		 
 Unser Beam Cut Charge: {H.Unser.scalerChargeCut:%.3f} uC
 
+**************************
+* Spectrometer Mispointing
+**************************
+X Mispointing:	{hmispointing_x:%.3f}
+Y Mispointing:	{hmispointing_y:%.3f}
+
 ********************
 * DAQ Configuration
 ********************

--- a/xem_setup.sh
+++ b/xem_setup.sh
@@ -198,6 +198,7 @@ if [[ ifarm_flg -eq 1 ]]; then
 	mkdir $base_dir_voli$USER"/REPORT_OUTPUT/COIN/CALIBRATION"
 	mkdir $base_dir_voli$USER"/REPORT_OUTPUT/COIN/PRODUCTION"
 	mkdir $base_dir_voli$USER"/REPORT_OUTPUT/COIN/SCALARS"
+	mkdir $base_dir_voli$USER"/REPORT_OUTPUT/COIN/HeeP"
 	mkdir $base_dir_voli$USER"/REPORT_OUTPUT/COIN/TIMING"
 	mkdir $base_dir_voli$USER"/REPORT_OUTPUT/COIN/shms50k"
 	mkdir $base_dir_voli$USER"/REPORT_OUTPUT/COIN/hms50k"


### PR DESCRIPTION
Point SHMS to fa22 template file.
Change template file in COIN standard.database.  Not currently used.
COIN runs have both SHMS and HMS mispointing (labeled).