### PR TITLE
HMS momentum offset update

### DIFF
--- a/PARAM/HMS/GEN/hmsflags_fa22.param
+++ b/PARAM/HMS/GEN/hmsflags_fa22.param
@@ -31,7 +31,7 @@ hphi_offset = 0.
                           ; Data taken with fields set by field00.f or later should set to 2000.
 ; These offsets are determined from elastic ep data.
 ; central field  correction
-  hpcentral_offset = 100*(-0.001309-0.00381771*exp(-0.5*((hpcentral-4.78053)/0.539479)**2))
+  hpcentral_offset = 100*(-0.001309-0.00381771*exp(-0.5*((hpcentral-4.78053)/0.539479)**2)) ; (%)
   hthetacentral_offset = 0.00 ; (rad) 
   h_oopcentral_offset = 0.00  ; (rad)
 ; sets hpcentral = hpcentral * ( 1. + hpcentral_offset / 100. )

--- a/PARAM/HMS/GEN/hmsflags_fa22.param
+++ b/PARAM/HMS/GEN/hmsflags_fa22.param
@@ -31,7 +31,7 @@ hphi_offset = 0.
                           ; Data taken with fields set by field00.f or later should set to 2000.
 ; These offsets are determined from elastic ep data.
 ; central field  correction
-  hpcentral_offset = -0.00 ; (%)     
+  hpcentral_offset = 100*(-0.001309-0.00381771*exp(-0.5*((hpcentral-4.78053)/0.539479)**2))
   hthetacentral_offset = 0.00 ; (rad) 
   h_oopcentral_offset = 0.00  ; (rad)
 ; sets hpcentral = hpcentral * ( 1. + hpcentral_offset / 100. )

--- a/SCRIPTS/HMS/hms_shared.h
+++ b/SCRIPTS/HMS/hms_shared.h
@@ -29,8 +29,8 @@ void setupParms(Int_t RunNumber) {
   gHcParms->Define("gen_run_number", "Run Number", RunNumber);
   gHcParms->AddString("g_ctp_database_filename", "DBASE/HMS/standard.database");
   gHcParms->Load(gHcParms->GetString("g_ctp_database_filename"), RunNumber);
-  gHcParms->Load(gHcParms->GetString("g_ctp_parm_filename"));
   gHcParms->Load(gHcParms->GetString("g_ctp_kinematics_filename"), RunNumber);
+  gHcParms->Load(gHcParms->GetString("g_ctp_parm_filename"));
   gHcParms->Load(gHcParms->GetString("g_ctp_det_calib_filename"));
   gHcParms->Load(gHcParms->GetString("g_ctp_bcm_calib_filename"));
   gHcParms->Load(gHcParms->GetString("g_ctp_optics_filename"));


### PR DESCRIPTION
Study of HMS elastics found there to be a slight offset in the HMS spectrometer momentum. This offset was momentum dependent. The offsets were fit with the constant minus a Gaussian as shown in these slides summarizing the study: https://hallcweb.jlab.org/elogs/X%3E1+%26+EMC/243.

The code was previously written in such a way that hpcentral was defined before hpcentral_offset, which made it impossible to have an hpcentral dependent hpcentral_offset. The order of file loading in hms_shared.h was changed so now hpcentral is defined before hpcentral_offset. This now allows us to have hpcentral_offset dependent on hpcentral.