### PR TITLE
Adding cut to EDTM TDC time.

### DIFF
--- a/DEF-files/HMS/PRODUCTION/TRIG/htrig_vars.def
+++ b/DEF-files/HMS/PRODUCTION/TRIG/htrig_vars.def
@@ -28,6 +28,7 @@ block T.hms.hPRLO_tdcTimeRaw
 block T.hms.hPRLO_tdcMultiplicity
 block T.hms.hPRHI_tdcTimeRaw
 block T.hms.hPRHI_tdcMultiplicity
-
+block T.hms.hEDTM_tdcTimeRaw
+block T.hms.hEDTM_tdcMultiplicity
 
 

--- a/PARAM/TRIG/thms_3of4_fa22.param
+++ b/PARAM/TRIG/thms_3of4_fa22.param
@@ -24,14 +24,14 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,   1400,   1400,   1400,   1200,   1600,      0,      0,      0,      0,
+                               0,   1400,   1400,   1400,   1100,   1600,      0,      0,      0,      0,
                                0,      0,   2000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                             1700,   1800,   1900,   1800,   2000,   2400,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0
 
 t_hms_TdcTimeWindowMax =    100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
-                            100000,   2300,   2300,   2400,   1500,   2200, 100000, 100000, 100000, 100000,
+                            100000,   2300,   2300,   2400,   1600,   2200, 100000, 100000, 100000, 100000,
                             100000, 100000,   2500, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                             100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                               2200,   2600,   2800,   2600,   3100,   3000, 100000, 100000, 100000, 100000,

--- a/PARAM/TRIG/thms_3of4_fa22.param
+++ b/PARAM/TRIG/thms_3of4_fa22.param
@@ -24,14 +24,14 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,   1400,   1400,   1400,      0,   1600,      0,      0,      0,      0,
+                               0,   1400,   1400,   1400,   1200,   1600,      0,      0,      0,      0,
                                0,      0,   2000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                             1700,   1800,   1900,   1800,   2000,   2400,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0
 
 t_hms_TdcTimeWindowMax =    100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
-                            100000,   2300,   2300,   2400, 100000,   2200, 100000, 100000, 100000, 100000,
+                            100000,   2300,   2300,   2400,   1500,   2200, 100000, 100000, 100000, 100000,
                             100000, 100000,   2500, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                             100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                               2200,   2600,   2800,   2600,   3100,   3000, 100000, 100000, 100000, 100000,

--- a/PARAM/TRIG/thms_3of4_fa22.param
+++ b/PARAM/TRIG/thms_3of4_fa22.param
@@ -24,14 +24,14 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,   1400,   1400,   1400,   1100,   1600,      0,      0,      0,      0,
+                               0,   1400,   1400,   1400,   1000,   1600,      0,      0,      0,      0,
                                0,      0,   2000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                             1700,   1800,   1900,   1800,   2000,   2400,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0
 
 t_hms_TdcTimeWindowMax =    100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
-                            100000,   2300,   2300,   2400,   1600,   2200, 100000, 100000, 100000, 100000,
+                            100000,   2300,   2300,   2400,   1800,   2200, 100000, 100000, 100000, 100000,
                             100000, 100000,   2500, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                             100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                               2200,   2600,   2800,   2600,   3100,   3000, 100000, 100000, 100000, 100000,

--- a/PARAM/TRIG/thms_elclean_fa22.param
+++ b/PARAM/TRIG/thms_elclean_fa22.param
@@ -23,7 +23,7 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,    800,    800,    800,   1200,    800,      0,      0,      0,      0,
+                               0,    800,    800,    800,    800,    800,      0,      0,      0,      0,
                                0,      0,   1000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                              700,   1000,   1300,   1200,   1400,   2000,      0,      0,      0,      0,

--- a/PARAM/TRIG/thms_elclean_fa22.param
+++ b/PARAM/TRIG/thms_elclean_fa22.param
@@ -23,14 +23,14 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,    800,    800,    800,      0,    800,      0,      0,      0,      0,
+                               0,    800,    800,    800,   1200,    800,      0,      0,      0,      0,
                                0,      0,   1000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                              700,   1000,   1300,   1200,   1400,   2000,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0
 
 t_hms_TdcTimeWindowMax =    100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
-                            100000,   1650,   1650,   1650,   2050, 100000, 100000, 100000, 100000, 100000,
+                            100000,   1650,   1650,   1650,   1500,   2050, 100000, 100000, 100000, 100000,
                             100000, 100000,   2000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                             100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                               1800,   1900,   2200,   2000,   2400,   2400, 100000, 100000, 100000, 100000,

--- a/PARAM/TRIG/thms_elclean_fa22.param
+++ b/PARAM/TRIG/thms_elclean_fa22.param
@@ -23,7 +23,7 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,    800,    800,    800,    800,    800,      0,      0,      0,      0,
+                               0,    800,    800,    800,    600,    800,      0,      0,      0,      0,
                                0,      0,   1000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                              700,   1000,   1300,   1200,   1400,   2000,      0,      0,      0,      0,

--- a/PARAM/TRIG/thms_elreal_fa22.param
+++ b/PARAM/TRIG/thms_elreal_fa22.param
@@ -23,14 +23,14 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,    700,    700,    800,      0,   1200,      0,      0,      0,      0,
+                               0,    700,    700,    800,   1200,   1200,      0,      0,      0,      0,
                                0,      0,   1000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                              600,    900,   1800,   1400,   1950,   2000,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0
 
 t_hms_TdcTimeWindowMax =    100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
-                            100000,   2000,   2100,   2200, 100000,   2200, 100000, 100000, 100000, 100000,
+                            100000,   2000,   2100,   2200,   1500,   2200, 100000, 100000, 100000, 100000,
                             100000, 100000,   2400, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                             100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                               2200,   2200,   2400,   2400,   2400,   2800, 100000, 100000, 100000, 100000,

--- a/PARAM/TRIG/thms_elreal_fa22.param
+++ b/PARAM/TRIG/thms_elreal_fa22.param
@@ -23,14 +23,14 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,    700,    700,    800,   1200,   1200,      0,      0,      0,      0,
+                               0,    700,    700,    800,   1000,   1200,      0,      0,      0,      0,
                                0,      0,   1000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                              600,    900,   1800,   1400,   1950,   2000,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0
 
 t_hms_TdcTimeWindowMax =    100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
-                            100000,   2000,   2100,   2200,   1500,   2200, 100000, 100000, 100000, 100000,
+                            100000,   2000,   2100,   2200,   1600,   2200, 100000, 100000, 100000, 100000,
                             100000, 100000,   2400, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                             100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                               2200,   2200,   2400,   2400,   2400,   2800, 100000, 100000, 100000, 100000,

--- a/PARAM/TRIG/thms_elreal_fa22.param
+++ b/PARAM/TRIG/thms_elreal_fa22.param
@@ -23,14 +23,14 @@ t_hms_adcNames = "hASUM hBSUM hCSUM hDSUM hPSHWR hSHWR hAER hCER hFADC_TREF_ROC1
 t_hms_tdcNames = "h1X h1Y h2X h2Y h1T h2T hT1 hASUM hBSUM hCSUM hDSUM hPRLO hPRHI hSHWR hEDTM hCER hT2 hDCREF1 hDCREF2 hDCREF3 hDCREF4 hDCREF5 hTRIG1 hTRIG2 hTRIG3 hTRIG4 hTRIG5 hTRIG6 pTRIG1 pTRIG2 pTRIG3 pTRIG4 pTRIG5 pTRIG6 pSTOF pEL_LO_LO pEL_LO pEL_HI pEL_REAL pEL_CLEAN hSTOF hEL_LO_LO hEL_LO hEL_HI hEL_REAL hEL_CLEAN  hT3 pPRE40 pPRE100 pPRE150 pPRE200 hPRE40 hPRE100 hPRE150 hPRE200 hRF hHODO_RF"
 
 t_hms_TdcTimeWindowMin =       0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
-                               0,    700,    700,    800,   1000,   1200,      0,      0,      0,      0,
+                               0,    700,    700,    800,    900,   1200,      0,      0,      0,      0,
                                0,      0,   1000,      0,      0,      0,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
                              600,    900,   1800,   1400,   1950,   2000,      0,      0,      0,      0,
                                0,      0,      0,      0,      0,      0,      0
 
 t_hms_TdcTimeWindowMax =    100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
-                            100000,   2000,   2100,   2200,   1600,   2200, 100000, 100000, 100000, 100000,
+                            100000,   2000,   2100,   2200,   1700,   2200, 100000, 100000, 100000, 100000,
                             100000, 100000,   2400, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                             100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000, 100000,
                               2200,   2200,   2400,   2400,   2400,   2800, 100000, 100000, 100000, 100000,


### PR DESCRIPTION
Adding cut to EDTM TDC time. Distributions used to determine cuts can be found in the following elog entry: https://hallcweb.jlab.org/elogs/X%3E1+%26+EMC/276